### PR TITLE
Fix typo in the Size properties table

### DIFF
--- a/input_variables_controlling_an_api_request.adoc
+++ b/input_variables_controlling_an_api_request.adoc
@@ -175,9 +175,9 @@ The input values used with some API calls as well as certain query parameters ar
 |GB
 |GB Gigabytes (MB x 1024 bytes) or gibibytes
 |TB
-|TB Terabytes (GB x 1024 byes) or tebibytes
+|TB Terabytes (GB x 1024 bytes) or tebibytes
 |PB
-|PB Petabytes (TB x 1024 byes) or pebibytes
+|PB Petabytes (TB x 1024 bytes) or pebibytes
 |===
 
 .Related links


### PR DESCRIPTION
bytes is misspelled as byes in the description column for two Suffix entries, TB and PB.