### PR TITLE
Fix grammatical error in common error codes table

### DIFF
--- a/interpreting_an_api_response.adoc
+++ b/interpreting_an_api_response.adoc
@@ -133,7 +133,7 @@ The common error codes are described in the following table. Specific API calls 
 |The operation is not supported.
 |4
 |405
-|An object with the specified identifier cannot be not found.
+|An object with the specified identifier cannot be found.
 |6
 |403
 |Permission to perform the request is denied.


### PR DESCRIPTION
Changed sentence from 'an object with the specified identifier cannot be NOT found' to 'an object with the specified identifier cannot be found'.  I think the second one should be the correct error description.