### PR TITLE
Update input_variables.adoc

### DIFF
--- a/rest/input_variables.adoc
+++ b/rest/input_variables.adoc
@@ -77,7 +77,7 @@ In addition to an exact match, other operators are available to return a set of 
 |Less than
 |>
 |Greater than
-|<=
+|\<=
 |Less than or equal to
 |>=
 |Greater than or equal to
@@ -152,7 +152,7 @@ The number of objects actually returned can be less than the maximum in effect, 
 Narrowing the result set::
 If needed, you can combine these two parameters with additional query parameters to narrow the result set. For example, the following returns up to 10 ems events generated after the specified time:
 +
-`time=> 2018-04-04T15:41:29.140265Z&max_records=10`
+`time>= 2018-04-04T15:41:29.140265Z&max_records=10`
 +
 You can issue multiple requests to page through the objects. Each subsequent API call should use a new time value based on the latest event in the last result set.
 


### PR DESCRIPTION
Fix less than or equal to having a substitution applied, fixed greater than or equal to symbol in an example.