### PR TITLE
Fix endpoint aggregates

### DIFF
--- a/workflows/wf_stor_list_aggrs.adoc
+++ b/workflows/wf_stor_list_aggrs.adoc
@@ -24,7 +24,7 @@ This REST API call uses the following method and endpoint.
 |HTTP method
 |Path
 |GET
-|/api/storage/disks
+|/api/storage/aggregates
 |===
 
 .Processing type


### PR DESCRIPTION
This pull request makes a small but important correction to the REST API documentation by updating the endpoint path for listing aggregates. Changed the existing documented API endpoint from `/api/storage/disks` to `/api/storage/aggregates` in `workflows/wf_stor_list_aggrs.adoc` to accurately reflect the correct REST API call.